### PR TITLE
add typing to caught errors in matcher

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -139,7 +139,7 @@ async function toBeVisible(
       }
     }, findOptions);
   } catch (err) {
-    error = err;
+    error = err as Error;
   }
 
   const options = {
@@ -183,7 +183,7 @@ async function toHaveFocus(
       }
     }, findOptions);
   } catch (err) {
-    error = err;
+    error = err as Error;
   }
 
   const options = {
@@ -218,7 +218,7 @@ async function toThrowQueryEmptyError(
   try {
     await promise;
   } catch (err) {
-    error = err;
+    error = err as Error;
   }
 
   pass = error?.name === 'QueryEmptyError';
@@ -293,8 +293,8 @@ async function toBeFound(
       { timeout: findOptions.timeout }
     );
   } catch (err) {
-    pass = err.name === 'QueryFoundError';
-    error = err;
+    error = err as Error;
+    pass = error.name === 'QueryFoundError';
   }
 
   const options = {


### PR DESCRIPTION
This PR fixes the following 5 errors I get when I run `npm install`:

$ tsc
src/matchers.ts:142:5 - error TS2322: Type 'unknown' is not assignable to type 'Error | null'.
  Type 'unknown' is not assignable to type 'Error'.

142     error = err;
        ~~~~~

src/matchers.ts:186:5 - error TS2322: Type 'unknown' is not assignable to type 'Error | null'.
  Type 'unknown' is not assignable to type 'Error'.

186     error = err;
        ~~~~~

src/matchers.ts:221:5 - error TS2322: Type 'unknown' is not assignable to type 'Error | null'.
  Type 'unknown' is not assignable to type 'Error'.

221     error = err;
        ~~~~~

src/matchers.ts:296:12 - error TS2571: Object is of type 'unknown'.

296     pass = err.name === 'QueryFoundError';
               ~~~

src/matchers.ts:297:5 - error TS2322: Type 'unknown' is not assignable to type 'Error'.

297     error = err;
        ~~~~~


Found 5 errors.
```

### Testing instructions

1. Run `npm i`